### PR TITLE
Fix escape sequences in StringLiteral's Display impl

### DIFF
--- a/src/literal.rs
+++ b/src/literal.rs
@@ -192,8 +192,8 @@ impl fmt::Display for StringLiteral {
 
 		for c in self.0.chars() {
 			match c {
-				'"' => write!(f, "\\u0022"),
-				'\\' => write!(f, "\\u005c"),
+				'"' => write!(f, "\\\""),
+				'\\' => write!(f, "\\\\"),
 				'\n' => write!(f, "\\n"),
 				'\r' => write!(f, "\\r"),
 				'\t' => write!(f, "\\t"),


### PR DESCRIPTION
The escaped characters should just be the escaped characters.